### PR TITLE
bcmoham-31376: update workflows to fix missing oc cli

### DIFF
--- a/.github/workflows/deploy-pbf-data-loader.yml
+++ b/.github/workflows/deploy-pbf-data-loader.yml
@@ -56,6 +56,11 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       # 1. Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1
@@ -156,6 +161,11 @@ jobs:
           echo "DEVOPS_DIR=${{needs.compute.outputs.DEVOPS_DIR}}"  | tee -a $GITHUB_ENV
           echo "IMAGE_ID=${{needs.compute.outputs.IMAGE_ID}}"  | tee -a $GITHUB_ENV
 
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       # Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1
@@ -219,6 +229,11 @@ jobs:
           echo "DEPLOY_SUFFIX=${{needs.compute.outputs.DEPLOY_SUFFIX}}"  | tee -a $GITHUB_ENV
           echo "DEVOPS_DIR=${{needs.compute.outputs.DEVOPS_DIR}}"  | tee -a $GITHUB_ENV
           echo "IMAGE_ID=${{needs.compute.outputs.IMAGE_ID}}"  | tee -a $GITHUB_ENV
+
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
 
       # Login to OpenShift
       - name: Log in to OpenShift

--- a/.github/workflows/release-pbf-data-loader.yml
+++ b/.github/workflows/release-pbf-data-loader.yml
@@ -105,6 +105,11 @@ jobs:
         run: |
           echo "This step should move the image to repository to dev namespace"
 
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       # Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1


### PR DESCRIPTION
Work Item: https://proactionca.ent.cgi.com/jira/browse/BCMOHAM-31376

Updates were made to the workflows to install the oc cli as it is no longer bundled with the runner used for the jobs. Updated workflows were:

- deploy-pbf-data-loader
- release-pbf-data-loader